### PR TITLE
feat: add gradle support for dart-define-from-file

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -22,6 +22,20 @@ if (flutterVersionName == null) {
     flutterVersionName = '1.0'
 }
 
+// Get the JSON file path from the command line
+def jsonFilePath = project.hasProperty('dart-define-from-file') ? project['dart-define-from-file'] : null
+
+// Read and parse the JSON file
+def jsonContents = null;
+if (jsonFilePath != null) {
+    def jsonFile = new File(jsonFilePath)
+    jsonContents = new groovy.json.JsonSlurper().parse(jsonFile)
+}
+
+// Access and print specific properties from the JSON file
+// For accessing any other param from secrets/<name>.json access using jsonContents.<keyName>
+def appId = jsonContents.appId ? jsonContents.appId : ''
+
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
@@ -46,7 +60,7 @@ android {
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId "com.example.myFlutterProjDemo"
+        applicationId "com.example.my_flutter_proj_demo"
         applicationIdSuffix appId
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.

--- a/android/app/src/androidTest/java/com/example/my_flutter_proj_demo/abc/MainActivityTest.java
+++ b/android/app/src/androidTest/java/com/example/my_flutter_proj_demo/abc/MainActivityTest.java
@@ -1,11 +1,11 @@
-package com.example.myFlutterProjDemo;
+package com.example.my_flutter_proj_demo;
 
  import androidx.test.rule.ActivityTestRule;
  import dev.flutter.plugins.integration_test.FlutterTestRunner;
  import org.junit.Rule;
  import org.junit.runner.RunWith;
 
- import com.example.myFlutterProjDemo.MainActivity;
+ import com.example.my_flutter_proj_demo.MainActivity;
 
  @RunWith(FlutterTestRunner.class)
  public class MainActivityTest {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -57,9 +57,9 @@ dev_dependencies:
 
 # The following section is specific to Flutter packages.
 flutter:
-  assets:
-    # - integration_test/e2eTestData.json
-    - integration_test_2/abc.txt
+  # assets:
+  #   # - integration_test/e2eTestData.json
+  #   - integration_test_2/abc.txt
 
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in


### PR DESCRIPTION
# What is the change

Adding support for --dart-define-from-file in build.gradle

# How to use

- Command to build testSuite app
`./gradlew app:assembleAndroidTest -Pdart-define-from-file="../.secrets/uat.json"`
- Command to build debug app
`./gradlew app:assembleDebug -Ptarget="$FCI_BUILD_DIR/integration_test/app_test.dart  -Pdart-define-from-file="../.secrets/uat.json"`

# Changes in this PR

1. Added handling for --dart-define-from-file cmdline param
2. moved MainActivityTest.java at path android/app/src/androidTest/java/com/example/my_flutter_proj_demo/abc/MainActivityTest.java as we are adding appId as applicationIdSuffix
3. Commented out assets as asset file did not exist 


